### PR TITLE
rpc: Add possibility to measure command execution time

### DIFF
--- a/nrf_rpc/Kconfig
+++ b/nrf_rpc/Kconfig
@@ -70,4 +70,11 @@ config NRF_RPC_THREAD_POOL_SIZE
 	  the remote side. If there is no available threads then remote side
 	  will wait.
 
+config NRF_RPC_COMMAND_TIME_MEASURE
+	bool "Measure command execution time"
+	help
+	  Measure the time between sending the command and receiving the response
+	  and log the value. Time measured includes the transmission and reception
+	  time. Log level for the time measurement is CONFIG_NRF_RPC_LOG_LEVEL_INF.
+
 endif # NRF_RPC

--- a/nrf_rpc/template/nrf_rpc_os_tmpl.h
+++ b/nrf_rpc/template/nrf_rpc_os_tmpl.h
@@ -169,6 +169,12 @@ void* nrf_rpc_os_tls_get(void);
  */
 void nrf_rpc_os_tls_set(void *data);
 
+/** @brief Get the current timestamp value.
+ *
+ * @return Current timestamp in milliseconds.
+ */
+uint64_t nrf_rpc_os_timestamp_get_now(void);
+
 /** @brief Reserve one context from command context pool.
  *
  * If there is no available context then this function waits for it.


### PR DESCRIPTION
Added measuring the command execution time. The time is printed as an INFO log level after the command is complete.